### PR TITLE
Fix!: Adjust padding for code blocks in Markdown wrapper

### DIFF
--- a/Frontend/src/App.css
+++ b/Frontend/src/App.css
@@ -44,7 +44,7 @@ main, footer {
     @apply bg-zinc-600 rounded-lg px-2 py-1;
   }
   code[class*="language"] {
-    @apply bg-zinc-800 px-1 rounded my-5 text-left;
+    @apply bg-zinc-800 px-5 rounded my-5 text-left;
   }
 
   ul {


### PR DESCRIPTION
Fixed Padding for code blocks

<img width="1080" height="1920" alt="image" src="https://github.com/user-attachments/assets/a7e6846f-5c2f-40cf-9e79-e07c2f583a24" />
